### PR TITLE
feat: Support of solr 9.x

### DIFF
--- a/vars/Linux.yml
+++ b/vars/Linux.yml
@@ -2,6 +2,7 @@
 default_solr_dest_main_path: /opt
 default_solr_configset_path: '{{ solr_home }}/configsets'
 
+# Solr 8.x and lower: master / masterUrl
 linux_master_config: |
           <lst name="master">
           <str name="replicateAfter">commit</str>
@@ -15,4 +16,22 @@ linux_slave_config: |
           <str name="pollInterval">00:00:60</str>
           </lst>
 
-default_solr_config_lines: '{{ (solr_instance_type == "master") | ternary(linux_master_config, linux_slave_config) }}'
+# Solr 9.x: leader / leaderUrl
+linux_master_config_9: |
+          <lst name="leader">
+          <str name="replicateAfter">commit</str>
+          <str name="replicateAfter">startup</str>
+          <str name="confFiles">schema.xml,stopwords.txt</str>
+          </lst>
+
+linux_slave_config_9: |
+          <lst name="follower">
+          <str name="leaderUrl">{{ solr_master_generated_url }}</str>
+          <str name="pollInterval">00:00:60</str>
+          </lst>
+
+# Select config by solr_version (9.x uses leader/leaderUrl)
+linux_master_config_selected: '{{ linux_master_config_9 if (solr_version is version("9.0", ">=")) else linux_master_config }}'
+linux_slave_config_selected: '{{ linux_slave_config_9 if (solr_version is version("9.0", ">=")) else linux_slave_config }}'
+
+default_solr_config_lines: '{{ (solr_instance_type == "master") | ternary(linux_master_config_selected, linux_slave_config_selected) }}'


### PR DESCRIPTION
In 9.x Solr version there is change related to renaming master to leader / slave to follower Described here: https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html

So the change will support without changes on playbook side, support 9.x version of solr and will use appropriate names according to version specified in solr_version

Tested successfully on our project